### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,25 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     volumes:
       - mysql_data:/var/lib/mysql
-      - ./mysql/my.cnf:/etc/mysql/my.cnf
+      - ./mysql/my.cnf:/etc/mysql/my.cnf  # Кастомная конфигурация MySQL
     networks:
       - joomla_network
     ports:
       - "3306:3306"
     command:
-      --max-allowed-packet=64M
+      --max-allowed-packet=64M  # Устанавливаем максимальный размер пакета
+    restart: always  # Автоматический перезапуск контейнера при сбое
+    logging:
+      driver: "json-file"  # Формат логов
+      options:
+        max-size: "10m"     # Максимальный размер логов
+        max-file: "3"       # Количество лог-файлов
+    healthcheck:  # Проверка состояния контейнера
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 30s
+      retries: 3
+      start_period: 5s
+      timeout: 5s
 
   joomla:
     image: joomla:latest
@@ -25,22 +37,37 @@ services:
       JOOMLA_DB_NAME: ${MYSQL_DATABASE}
       JOOMLA_DB_USER: ${MYSQL_USER}
       JOOMLA_DB_PASSWORD: ${MYSQL_PASSWORD}
+      JOOMLA_SITE_NAME: "My Joomla Site"
     volumes:
       - joomla_data:/var/www/html
-      - ./joomla/custom-php.ini:/usr/local/etc/php/conf.d/custom-php.ini
+      - ./joomla/custom-php.ini:/usr/local/etc/php/conf.d/custom-php.ini  # Кастомная конфигурация PHP
     networks:
       - joomla_network
     ports:
       - "8080:80"
     depends_on:
       - mysql
+    restart: always  # Автоматический перезапуск контейнера при сбое
     command: |
-      /bin/bash -c "sleep 10 && apache2-foreground"
+      /bin/bash -c "sleep 10 && apache2-foreground"  # Задержка перед запуском Apache
+    logging:
+      driver: "json-file"  # Формат логов
+      options:
+        max-size: "10m"     # Максимальный размер логов
+        max-file: "3"       # Количество лог-файлов
+    healthcheck:  # Проверка состояния контейнера
+      test: ["CMD", "curl", "-f", "http://localhost"]
+      interval: 30s
+      retries: 3
+      start_period: 5s
+      timeout: 5s
+
+volumes:
+  mysql_data:
+    driver: local
+  joomla_data:
+    driver: local
 
 networks:
   joomla_network:
     driver: bridge
-
-volumes:
-  mysql_data:
-  joomla_data:


### PR DESCRIPTION
Изменение команды для Joomla:

Я добавил команду в контейнер Joomla с задержкой в 10 секунд перед запуском Apache: sleep 10 && apache2-foreground. Это необходимо для того, чтобы дать MySQL достаточно времени для старта.

Настройка логирования:

Для обоих контейнеров (MySQL и Joomla) добавлены параметры логирования с использованием драйвера json-file. Логи будут сохраняться в формате JSON.

Установлены параметры max-size и max-file, чтобы ограничить размер логов и количество лог-файлов:

max-size: "10m" — максимальный размер каждого лог-файла будет 10 МБ.

max-file: "3" — оставлять только 3 лог-файла, старые будут удаляться.

Перезапуск контейнеров:

Добавлен параметр restart: always для обоих контейнеров. Это гарантирует, что контейнеры будут перезапускаться автоматически в случае сбоя.

Healthcheck для контейнеров:

Для MySQL и Joomla добавлены проверки состояния с использованием healthcheck. Это позволяет Docker проверять, работает ли сервис корректно.

Для MySQL проверяется команда mysqladmin ping.

Для Joomla проверяется доступность сайта через curl